### PR TITLE
Shared filetree

### DIFF
--- a/syft/source/directory_resolver.go
+++ b/syft/source/directory_resolver.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/filetree"
@@ -308,12 +309,19 @@ func (r *directoryResolver) FileMetadataByLocation(location Location) (FileMetad
 		return FileMetadata{}, fmt.Errorf("location: %+v : %w", location, os.ErrNotExist)
 	}
 
+	uid := -1
+	gid := -1
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		uid = int(stat.Uid)
+		gid = int(stat.Gid)
+	}
+
 	return FileMetadata{
 		Mode: info.Mode(),
 		Type: newFileTypeFromMode(info.Mode()),
 		// unsupported across platforms
-		UserID:  -1,
-		GroupID: -1,
+		UserID:  uid,
+		GroupID: gid,
 	}, nil
 }
 

--- a/syft/source/directory_resolver.go
+++ b/syft/source/directory_resolver.go
@@ -326,6 +326,8 @@ func indexAllRoots(root string, indexer func(string, *progress.Stage) ([]string,
 	// in which case we need to additionally index where the link resolves to. it's for this reason why the filetree
 	// must be relative to the root of the filesystem (and not just relative to the given path).
 	pathsToIndex := []string{root}
+	fullPathsMap := map[string]struct{}{}
+
 	stager, prog := indexingProgress(root)
 	defer prog.SetCompleted()
 loop:
@@ -344,7 +346,13 @@ loop:
 		if err != nil {
 			return fmt.Errorf("unable to index filesystem path=%q: %w", currentPath, err)
 		}
-		pathsToIndex = append(pathsToIndex, additionalRoots...)
+
+		for _, newRoot := range additionalRoots {
+			if _, ok := fullPathsMap[newRoot]; !ok {
+				fullPathsMap[newRoot] = struct{}{}
+				pathsToIndex = append(pathsToIndex, newRoot)
+			}
+		}
 	}
 
 	return nil

--- a/syft/source/directory_resolver_test.go
+++ b/syft/source/directory_resolver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/filetree"
 	"github.com/stretchr/testify/assert"
 	"github.com/wagoodman/go-progress"
 )
@@ -65,7 +66,7 @@ func TestDirectoryResolver_FilesByPath(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			resolver, err := newDirectoryResolver(c.root)
+			resolver, err := newDirectoryResolver(nil, c.root)
 			assert.NoError(t, err)
 
 			hasPath := resolver.HasPath(c.input)
@@ -121,7 +122,7 @@ func TestDirectoryResolver_MultipleFilesByPath(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			resolver, err := newDirectoryResolver("./test-fixtures")
+			resolver, err := newDirectoryResolver(nil, "./test-fixtures")
 			assert.NoError(t, err)
 			refs, err := resolver.FilesByPath(c.input...)
 			assert.NoError(t, err)
@@ -133,8 +134,59 @@ func TestDirectoryResolver_MultipleFilesByPath(t *testing.T) {
 	}
 }
 
+func TestDirectoryResolver_SharedTreeMultipleFilesByPath(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    []string
+		refCount int
+	}{
+		{
+			name:     "finds multiple files first resolver",
+			input:    []string{"test-fixtures/image-symlinks/file-1.txt", "test-fixtures/image-symlinks/file-2.txt"},
+			refCount: 2,
+		},
+		{
+			name:     "skips non-existing files",
+			input:    []string{"test-fixtures/image-symlinks/bogus.txt", "test-fixtures/image-symlinks/file-1.txt"},
+			refCount: 1,
+		},
+		{
+			name:     "does not return anything for non-existing directories",
+			input:    []string{"test-fixtures/non-existing/bogus.txt", "test-fixtures/non-existing/file-1.txt"},
+			refCount: 0,
+		},
+		{
+			name:     "find file second resolver",
+			input:    []string{"test-fixtures/path-detected/.vimrc"},
+			refCount: 1,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fileTree := filetree.NewFileTree()
+			first_resolver, err := newDirectoryResolver(fileTree, "./test-fixtures/image-symlinks")
+			assert.NoError(t, err)
+			second_resolver, err := newDirectoryResolver(fileTree, "./test-fixtures/path-detected")
+			assert.NoError(t, err)
+
+			first_refs, err := first_resolver.FilesByPath(c.input...)
+			assert.NoError(t, err)
+			second_refs, err := second_resolver.FilesByPath(c.input...)
+			assert.NoError(t, err)
+
+			if len(first_refs) != len(second_refs) {
+				t.Errorf("unsynced number of refs: %d != %d", len(first_refs), len(second_refs))
+			}
+
+			if len(first_refs) != c.refCount {
+				t.Errorf("unexpected number of refs: %d != %d", len(first_refs), c.refCount)
+			}
+		})
+	}
+}
+
 func TestDirectoryResolver_FilesByGlobMultiple(t *testing.T) {
-	resolver, err := newDirectoryResolver("./test-fixtures")
+	resolver, err := newDirectoryResolver(nil, "./test-fixtures")
 	assert.NoError(t, err)
 	refs, err := resolver.FilesByGlob("**/image-symlinks/file*")
 	assert.NoError(t, err)
@@ -143,7 +195,7 @@ func TestDirectoryResolver_FilesByGlobMultiple(t *testing.T) {
 }
 
 func TestDirectoryResolver_FilesByGlobRecursive(t *testing.T) {
-	resolver, err := newDirectoryResolver("./test-fixtures/image-symlinks")
+	resolver, err := newDirectoryResolver(nil, "./test-fixtures/image-symlinks")
 	assert.NoError(t, err)
 	refs, err := resolver.FilesByGlob("**/*.txt")
 	assert.NoError(t, err)
@@ -151,7 +203,7 @@ func TestDirectoryResolver_FilesByGlobRecursive(t *testing.T) {
 }
 
 func TestDirectoryResolver_FilesByGlobSingle(t *testing.T) {
-	resolver, err := newDirectoryResolver("./test-fixtures")
+	resolver, err := newDirectoryResolver(nil, "./test-fixtures")
 	assert.NoError(t, err)
 	refs, err := resolver.FilesByGlob("**/image-symlinks/*1.txt")
 	assert.NoError(t, err)
@@ -162,7 +214,7 @@ func TestDirectoryResolver_FilesByGlobSingle(t *testing.T) {
 
 func TestDirectoryResolverDoesNotIgnoreRelativeSystemPaths(t *testing.T) {
 	// let's make certain that "dev/place" is not ignored, since it is not "/dev/place"
-	resolver, err := newDirectoryResolver("test-fixtures/system_paths/target")
+	resolver, err := newDirectoryResolver(nil, "test-fixtures/system_paths/target")
 	assert.NoError(t, err)
 	// ensure the correct filter function is wired up by default
 	expectedFn := reflect.ValueOf(isUnixSystemRuntimePath)
@@ -198,7 +250,7 @@ func TestDirectoryResolverUsesPathFilterFunction(t *testing.T) {
 		return strings.Contains(s, "dev/place") || strings.Contains(s, "proc/place") || strings.Contains(s, "sys/place")
 	}
 
-	resolver, err := newDirectoryResolver("test-fixtures/system_paths/target", filter)
+	resolver, err := newDirectoryResolver(nil, "test-fixtures/system_paths/target", filter)
 	assert.NoError(t, err)
 
 	// ensure the correct filter function is wired up by default
@@ -260,7 +312,7 @@ func Test_isUnixSystemRuntimePath(t *testing.T) {
 
 func Test_directoryResolver_index(t *testing.T) {
 	// note: this test is testing the effects from newDirectoryResolver, indexTree, and addPathToIndex
-	r, err := newDirectoryResolver("test-fixtures/system_paths/target")
+	r, err := newDirectoryResolver(nil, "test-fixtures/system_paths/target")
 	if err != nil {
 		t.Fatalf("unable to get indexed dir resolver: %+v", err)
 	}

--- a/syft/source/source_test.go
+++ b/syft/source/source_test.go
@@ -77,7 +77,6 @@ func TestNewFromDirectory(t *testing.T) {
 			assert.NoError(t, err)
 
 			refs, err := resolver.FilesByPath(test.inputPaths...)
-
 			if err != nil {
 				t.Errorf("FilesByPath call produced an error: %+v", err)
 			}
@@ -85,8 +84,8 @@ func TestNewFromDirectory(t *testing.T) {
 				t.Errorf("unexpected number of refs returned: %d != %d", len(refs), test.expRefs)
 
 			}
-		})
 
+		})
 	}
 }
 

--- a/syft/source/source_test.go
+++ b/syft/source/source_test.go
@@ -77,6 +77,7 @@ func TestNewFromDirectory(t *testing.T) {
 			assert.NoError(t, err)
 
 			refs, err := resolver.FilesByPath(test.inputPaths...)
+
 			if err != nil {
 				t.Errorf("FilesByPath call produced an error: %+v", err)
 			}
@@ -84,8 +85,8 @@ func TestNewFromDirectory(t *testing.T) {
 				t.Errorf("unexpected number of refs returned: %d != %d", len(refs), test.expRefs)
 
 			}
-
 		})
+
 	}
 }
 


### PR DESCRIPTION
Support of `Filetree` sharing between directory resolvers is needed to enable directory sources in the power user command.

**Following issues are targeted**
* Share `Filetree` between resolver via `source` struct. 
* Thread save directory resolver indexing - Adding a lock around the indexing logic
* Share indexed file information - copied shared tree references before indexing.
* Fix file metadata GID,UID sample (Linux based only).

**Test**
* Added shared directory unit test - `TestDirectoryResolver_SharedTreeMultipleFilesByPath`
